### PR TITLE
[Feature] Member와 Communtiy(Board,Comment) 엔터티 초안 완성

### DIFF
--- a/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
+++ b/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
@@ -1,0 +1,53 @@
+package org.hmanwon.domain.community.board.entity;
+
+import java.awt.PageAttributes.MediaType;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Comment;
+import org.hmanwon.domain.member.entity.Member;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Board {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("게시판 ID")
+    private Long id;
+
+    @Column(nullable = false)
+    @Comment("게시판 제목")
+    private String title;
+
+    @Column(nullable = false)
+    @Comment("게시판 글 내용")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @Comment("회원 FK")
+    private Member member;
+
+    @OneToMany(mappedBy = "board",
+        cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, orphanRemoval = true)
+    @Setter // 연간관계 메서드로 바꿔야 함
+    private List<org.hmanwon.domain.community.comment.entity.Comment> commentList = new ArrayList<>();
+}

--- a/src/main/java/org/hmanwon/domain/community/comment/entity/Comment.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/entity/Comment.java
@@ -1,0 +1,43 @@
+package org.hmanwon.domain.community.comment.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hmanwon.domain.community.board.entity.Board;
+import org.hmanwon.domain.member.entity.Member;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @org.hibernate.annotations.Comment("댓글 ID")
+    private Long id;
+
+    @Column(nullable = false)
+    @org.hibernate.annotations.Comment("댓글 내용")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @org.hibernate.annotations.Comment("회원 FK")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    @org.hibernate.annotations.Comment("게시판 FK")
+    private Board board;
+}

--- a/src/main/java/org/hmanwon/domain/member/dao/MemberRepository.java
+++ b/src/main/java/org/hmanwon/domain/member/dao/MemberRepository.java
@@ -1,0 +1,5 @@
+package org.hmanwon.domain.member.dao;
+
+public class MemberRepository  {
+
+}

--- a/src/main/java/org/hmanwon/domain/member/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/member/entity/Member.java
@@ -1,0 +1,58 @@
+package org.hmanwon.domain.member.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hmanwon.domain.community.board.entity.Board;
+import org.hmanwon.domain.community.comment.entity.Comment;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @org.hibernate.annotations.Comment("회원 ID")
+    private Long id;
+
+    @Column(nullable = false)
+    @org.hibernate.annotations.Comment("회원 email")
+    private String email;
+
+    @Column(nullable = false)
+    @org.hibernate.annotations.Comment("회원 닉네임")
+    private String nickName;
+
+    @Column(nullable = false)
+    @org.hibernate.annotations.Comment("회원 포인트")
+    @Min(0)
+    private Long point;
+
+    @OneToMany(mappedBy = "member",
+        cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
+    @Setter // 연간관계 메서드로 바꿔야 함
+    private List<Board> boardList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member",
+        cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
+    @Setter // 연간관계 메서드로 바꿔야 함
+    private List<Comment> commentList = new ArrayList<>();
+
+}

--- a/src/main/java/org/hmanwon/domain/user/dao/MemberRepository.java
+++ b/src/main/java/org/hmanwon/domain/user/dao/MemberRepository.java
@@ -1,7 +1,0 @@
-package org.hmanwon.domain.user.dao;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public class MemberRepository  {
-
-}

--- a/src/main/java/org/hmanwon/domain/user/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/user/entity/Member.java
@@ -1,6 +1,0 @@
-package org.hmanwon.domain.user.entity;
-
-//domain 안의 domain이 이상해서 entity로 바꿔야 하나 고민입니다.
-public class Member {
-
-}

--- a/src/main/java/org/hmanwon/domain/zzan_purchase/dao/MemberRepository.java
+++ b/src/main/java/org/hmanwon/domain/zzan_purchase/dao/MemberRepository.java
@@ -1,7 +1,0 @@
-package org.hmanwon.domain.zzan_purchase.dao;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MemberRepository {
-
-}

--- a/src/main/java/org/hmanwon/domain/zzan_purchase/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/zzan_purchase/entity/Member.java
@@ -1,6 +1,0 @@
-package org.hmanwon.domain.zzan_purchase.entity;
-
-//domain 안의 domain이 이상해서 entity로 바꿔야 하나 고민입니다.
-public class Member {
-
-}


### PR DESCRIPTION
# 변경 사항
Member와 Communtiy(Board,Comment) 엔터티 초안을 완성했습니다.
# 참고 사항
1. 게시글의 사진은 에타처럼 글과 사진 필드를 따로 두기로 했습니다.
이유: 게시글과 사진을 하나의 필드로 한 번에 저장하면 좋지만 그 방법을 못 찾음
이후: 사진은 클라우드의 NoSQL DB를 사용하여 저장 후 url을 사용하는데, NoSQL DB의 사진 저장 방식을 익힌 후 의인님이 게시글의 사진 추가 기능을 구현하시기로 했습니다.
2.  FetchType.LAZY 
3. 지금 Setter로 된 연간 관계 메서드를 구현해야 합니다