### PR TITLE
[Feature] 기획 요구에 맞게 해시 태그, 이미지, 게시글 생성, 상세 조회 기능 구현 

### DIFF
--- a/src/main/java/org/hmanwon/HManwonApplication.java
+++ b/src/main/java/org/hmanwon/HManwonApplication.java
@@ -2,7 +2,9 @@ package org.hmanwon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication()
 public class HManwonApplication {
 

--- a/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
+++ b/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
@@ -1,0 +1,48 @@
+package org.hmanwon.domain.community.board.application;
+
+import static org.hmanwon.domain.community.board.exception.BoardExceptionCode.NOT_FOUND_BOARD;
+import static org.hmanwon.domain.member.exception.MemberExceptionCode.NOT_FOUND_MEMBER;
+
+import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.community.board.dao.BoardRepository;
+import org.hmanwon.domain.community.board.dto.request.BoardWriteRequest;
+import org.hmanwon.domain.community.board.dto.response.BoardDetailResponse;
+import org.hmanwon.domain.community.board.dto.response.BoardResponse;
+import org.hmanwon.domain.community.board.entity.Board;
+import org.hmanwon.domain.community.board.exception.BoardException;
+import org.hmanwon.domain.member.dao.MemberRepository;
+import org.hmanwon.domain.member.entity.Member;
+import org.hmanwon.domain.member.exception.MemberException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository; //나중에 service로 바꿔야 함-
+
+    public Page<BoardResponse> getAllBoard(Pageable pageable) {
+        return boardRepository.findAll(pageable).map(BoardResponse::fromBoard);
+    }
+
+    public BoardDetailResponse getBoardDetail(Long boardId) {
+        return boardRepository.findById(boardId)
+            .map(BoardDetailResponse::fromBoard)
+            .orElseThrow(() -> new BoardException(NOT_FOUND_BOARD));
+    }
+
+    //나중에 BoardWriteRequest 검증 하는 로직 추가 하겠습니다 -> 커밋 리뷰에 제가 안 남기면 알려주세요
+    public Board createBoard(Long memberId, BoardWriteRequest boardWriteRequest) {
+        //멤버 서비스로 빼고 예외도 거기서 해야 함
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+
+        Board board = Board.of(
+            boardWriteRequest.title(), boardWriteRequest.content(), member
+        );
+        return boardRepository.save(board);
+    }
+}

--- a/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
+++ b/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
@@ -3,6 +3,8 @@ package org.hmanwon.domain.community.board.application;
 import static org.hmanwon.domain.community.board.exception.BoardExceptionCode.NOT_FOUND_BOARD;
 import static org.hmanwon.domain.member.exception.MemberExceptionCode.NOT_FOUND_MEMBER;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hmanwon.domain.community.board.dao.BoardRepository;
 import org.hmanwon.domain.community.board.dto.request.BoardWriteRequest;
@@ -10,6 +12,7 @@ import org.hmanwon.domain.community.board.dto.response.BoardDetailResponse;
 import org.hmanwon.domain.community.board.dto.response.BoardResponse;
 import org.hmanwon.domain.community.board.entity.Board;
 import org.hmanwon.domain.community.board.exception.BoardException;
+import org.hmanwon.domain.member.application.MemberService;
 import org.hmanwon.domain.member.dao.MemberRepository;
 import org.hmanwon.domain.member.entity.Member;
 import org.hmanwon.domain.member.exception.MemberException;
@@ -22,10 +25,12 @@ import org.springframework.stereotype.Service;
 public class BoardService {
 
     private final BoardRepository boardRepository;
-    private final MemberRepository memberRepository; //나중에 service로 바꿔야 함-
+    private final MemberService memberService;
 
-    public Page<BoardResponse> getAllBoard(Pageable pageable) {
-        return boardRepository.findAll(pageable).map(BoardResponse::fromBoard);
+    public List<BoardResponse> getAllBoard() {
+        return boardRepository.findAll()
+            .stream().map(BoardResponse::fromBoard)
+            .collect(Collectors.toList());
     }
 
     public BoardDetailResponse getBoardDetail(Long boardId) {
@@ -37,11 +42,10 @@ public class BoardService {
     //나중에 BoardWriteRequest 검증 하는 로직 추가 하겠습니다 -> 커밋 리뷰에 제가 안 남기면 알려주세요
     public Board createBoard(Long memberId, BoardWriteRequest boardWriteRequest) {
         //멤버 서비스로 빼고 예외도 거기서 해야 함
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+        Member member = memberService.getMemberById(memberId);
 
         Board board = Board.of(
-            boardWriteRequest.title(), boardWriteRequest.content(), member
+            boardWriteRequest.content(), member
         );
         return boardRepository.save(board);
     }

--- a/src/main/java/org/hmanwon/domain/community/board/dto/request/BoardWriteRequest.java
+++ b/src/main/java/org/hmanwon/domain/community/board/dto/request/BoardWriteRequest.java
@@ -1,0 +1,8 @@
+package org.hmanwon.domain.community.board.dto.request;
+
+public record BoardWriteRequest(
+    String title,
+    String content
+) {
+
+}

--- a/src/main/java/org/hmanwon/domain/community/board/dto/request/BoardWriteRequest.java
+++ b/src/main/java/org/hmanwon/domain/community/board/dto/request/BoardWriteRequest.java
@@ -1,7 +1,6 @@
 package org.hmanwon.domain.community.board.dto.request;
 
 public record BoardWriteRequest(
-    String title,
     String content
 ) {
 

--- a/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardDetailResponse.java
+++ b/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardDetailResponse.java
@@ -1,0 +1,27 @@
+package org.hmanwon.domain.community.board.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import org.hmanwon.domain.community.board.entity.Board;
+import org.hmanwon.domain.community.comment.entity.Comment;
+
+@Builder
+public record BoardDetailResponse(
+    String memberNickName,
+    Long boardId,
+    String title,
+    String content,
+    List<Comment> commentList
+
+) {
+
+    public static BoardDetailResponse fromBoard(Board board) {
+        return BoardDetailResponse.builder()
+            .memberNickName(board.getMember().getNickName())
+            .boardId(board.getId())
+            .title(board.getTitle())
+            .content(board.getContent())
+            .commentList(board.getCommentList())
+            .build();
+    }
+}

--- a/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardDetailResponse.java
+++ b/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardDetailResponse.java
@@ -9,7 +9,6 @@ import org.hmanwon.domain.community.comment.entity.Comment;
 public record BoardDetailResponse(
     String memberNickName,
     Long boardId,
-    String title,
     String content,
     List<Comment> commentList
 
@@ -19,7 +18,6 @@ public record BoardDetailResponse(
         return BoardDetailResponse.builder()
             .memberNickName(board.getMember().getNickName())
             .boardId(board.getId())
-            .title(board.getTitle())
             .content(board.getContent())
             .commentList(board.getCommentList())
             .build();

--- a/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardResponse.java
+++ b/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardResponse.java
@@ -7,7 +7,8 @@ import org.hmanwon.domain.community.board.entity.Board;
 public record BoardResponse(
     String memberNickName,
     Long boardId,
-    String title
+    String content
+
 
 ) {
 
@@ -15,7 +16,6 @@ public record BoardResponse(
         return BoardResponse.builder()
             .memberNickName(board.getMember().getNickName())
             .boardId(board.getId())
-            .title(board.getTitle())
             .build();
     }
 

--- a/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardResponse.java
+++ b/src/main/java/org/hmanwon/domain/community/board/dto/response/BoardResponse.java
@@ -1,0 +1,22 @@
+package org.hmanwon.domain.community.board.dto.response;
+
+import lombok.Builder;
+import org.hmanwon.domain.community.board.entity.Board;
+
+@Builder
+public record BoardResponse(
+    String memberNickName,
+    Long boardId,
+    String title
+
+) {
+
+    public static BoardResponse fromBoard(Board board) {
+        return BoardResponse.builder()
+            .memberNickName(board.getMember().getNickName())
+            .boardId(board.getId())
+            .title(board.getTitle())
+            .build();
+    }
+
+}

--- a/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
+++ b/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
@@ -16,7 +16,7 @@ import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Comment;
+import org.hmanwon.domain.community.comment.entity.Comment;
 import org.hmanwon.domain.member.entity.Member;
 import org.hmanwon.global.common.entity.BaseTimeEntity;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -30,29 +30,25 @@ public class Board extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Comment("게시판 ID")
     private Long id;
 
     @Column(nullable = false)
-    @Comment("게시판 제목")
     private String title;
 
     @Column(nullable = false)
-    @Comment("게시판 글 내용")
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    @Comment("회원 FK")
     private Member member;
 
     @OneToMany(mappedBy = "board",
         cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, orphanRemoval = true)
-    private List<org.hmanwon.domain.community.comment.entity.Comment> commentList =
+    private List<Comment> commentList =
         new ArrayList<>();
 
     public void setCommentList(
-        List<org.hmanwon.domain.community.comment.entity.Comment> commentList) {
+        List<Comment> commentList) {
         this.commentList = commentList;
     }
 }

--- a/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
+++ b/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
@@ -16,7 +16,6 @@ import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.Comment;
 import org.hmanwon.domain.member.entity.Member;
 import org.hmanwon.global.common.entity.BaseTimeEntity;
@@ -28,6 +27,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Board extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("게시판 ID")
@@ -48,6 +48,11 @@ public class Board extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "board",
         cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, orphanRemoval = true)
-    @Setter // 연간관계 메서드로 바꿔야 함
-    private List<org.hmanwon.domain.community.comment.entity.Comment> commentList = new ArrayList<>();
+    private List<org.hmanwon.domain.community.comment.entity.Comment> commentList =
+        new ArrayList<>();
+
+    public void setCommentList(
+        List<org.hmanwon.domain.community.comment.entity.Comment> commentList) {
+        this.commentList = commentList;
+    }
 }

--- a/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
+++ b/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
@@ -32,29 +32,34 @@ public class Board extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String title;
+    private String content;
+
+    private Double longitude;
+    private Double latitude;
 
     @Column(nullable = false)
-    private String content;
+    private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @OneToMany(mappedBy = "board",
-        cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, orphanRemoval = true)
-    private List<Comment> commentList =
-        new ArrayList<>();
+        cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<BoardHashtag> boardHashtags;
+
+    @OneToMany(mappedBy = "board",
+        cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Comment> commentList = new ArrayList<>();
 
     public void setCommentList(
         List<Comment> commentList) {
         this.commentList = commentList;
     }
 
-    public static Board of(String title, String content, Member member) {
+    public static Board of(String content, Member member) {
         return Board
             .builder()
-            .title(title)
             .content(content)
             .member(member)
             .build();

--- a/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
+++ b/src/main/java/org/hmanwon/domain/community/board/entity/Board.java
@@ -5,7 +5,6 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,18 +13,18 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hmanwon.domain.community.comment.entity.Comment;
 import org.hmanwon.domain.member.entity.Member;
 import org.hmanwon.global.common.entity.BaseTimeEntity;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Board extends BaseTimeEntity {
 
     @Id
@@ -50,5 +49,14 @@ public class Board extends BaseTimeEntity {
     public void setCommentList(
         List<Comment> commentList) {
         this.commentList = commentList;
+    }
+
+    public static Board of(String title, String content, Member member) {
+        return Board
+            .builder()
+            .title(title)
+            .content(content)
+            .member(member)
+            .build();
     }
 }

--- a/src/main/java/org/hmanwon/domain/community/board/entity/BoardHashtag.java
+++ b/src/main/java/org/hmanwon/domain/community/board/entity/BoardHashtag.java
@@ -1,0 +1,36 @@
+package org.hmanwon.domain.community.board.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hmanwon.domain.community.board.entity.Board;
+import org.hmanwon.domain.community.board.entity.Hashtag;
+import org.hmanwon.global.common.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardHashtag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @ManyToOne
+    @JoinColumn(name = "hashtage_id")
+    private Hashtag hashtag;
+
+}

--- a/src/main/java/org/hmanwon/domain/community/board/entity/Hashtag.java
+++ b/src/main/java/org/hmanwon/domain/community/board/entity/Hashtag.java
@@ -1,0 +1,36 @@
+package org.hmanwon.domain.community.board.entity;
+
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hmanwon.global.common.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Hashtag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "hashtag",
+        cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, orphanRemoval = true)
+    private List<BoardHashtag> boardHashtags;
+
+}

--- a/src/main/java/org/hmanwon/domain/community/board/exception/BoardException.java
+++ b/src/main/java/org/hmanwon/domain/community/board/exception/BoardException.java
@@ -1,0 +1,11 @@
+package org.hmanwon.domain.community.board.exception;
+
+import org.hmanwon.global.common.exception.DefaultException;
+import org.hmanwon.global.common.exception.ExceptionCode;
+
+public class BoardException extends DefaultException {
+
+    public BoardException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+}

--- a/src/main/java/org/hmanwon/domain/community/board/exception/BoardExceptionCode.java
+++ b/src/main/java/org/hmanwon/domain/community/board/exception/BoardExceptionCode.java
@@ -1,0 +1,20 @@
+package org.hmanwon.domain.community.board.exception;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hmanwon.global.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BoardExceptionCode implements ExceptionCode {
+
+    NOT_FOUND_BOARD(INTERNAL_SERVER_ERROR, "Board Error 01", "게시글이 존재하지 않습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+}

--- a/src/main/java/org/hmanwon/domain/community/board/presentation/BoardController.java
+++ b/src/main/java/org/hmanwon/domain/community/board/presentation/BoardController.java
@@ -1,14 +1,12 @@
 package org.hmanwon.domain.community.board.presentation;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hmanwon.domain.community.board.application.BoardService;
 import org.hmanwon.domain.community.board.dto.request.BoardWriteRequest;
 import org.hmanwon.domain.community.board.dto.response.BoardDetailResponse;
 import org.hmanwon.domain.community.board.dto.response.BoardResponse;
 import org.hmanwon.global.common.dto.ResponseDTO;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,13 +38,12 @@ public class BoardController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDTO<Page<BoardResponse>>> getAllBoard(
-        @PageableDefault(size = 12)Pageable pageable
+    public ResponseEntity<ResponseDTO<List<BoardResponse>>> getAllBoard(
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(
                 HttpStatus.OK,
-                boardService.getAllBoard(pageable),
+                boardService.getAllBoard(),
                 "게시글을 모두 조회 했습니다.")
         );
     }

--- a/src/main/java/org/hmanwon/domain/community/board/presentation/BoardController.java
+++ b/src/main/java/org/hmanwon/domain/community/board/presentation/BoardController.java
@@ -1,0 +1,65 @@
+package org.hmanwon.domain.community.board.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.community.board.application.BoardService;
+import org.hmanwon.domain.community.board.dto.request.BoardWriteRequest;
+import org.hmanwon.domain.community.board.dto.response.BoardDetailResponse;
+import org.hmanwon.domain.community.board.dto.response.BoardResponse;
+import org.hmanwon.global.common.dto.ResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<BoardResponse>> createBoard(
+        @RequestParam Long memberId,
+        @RequestBody BoardWriteRequest boardWriteRequest
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDTO.res(
+                HttpStatus.OK,
+                BoardResponse.fromBoard(boardService.createBoard(memberId,boardWriteRequest)),
+                "게시글을 생성 했습니다.")
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<Page<BoardResponse>>> getAllBoard(
+        @PageableDefault(size = 12)Pageable pageable
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDTO.res(
+                HttpStatus.OK,
+                boardService.getAllBoard(pageable),
+                "게시글을 모두 조회 했습니다.")
+        );
+    }
+
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ResponseDTO<BoardDetailResponse>> getBoardDetail(
+        @PathVariable Long boardId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDTO.res(
+                HttpStatus.OK,
+                boardService.getBoardDetail(boardId),
+                "게시글을 모두 조회 했습니다.")
+        );
+    }
+}

--- a/src/main/java/org/hmanwon/domain/community/comment/entity/Comment.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/entity/Comment.java
@@ -22,21 +22,17 @@ public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @org.hibernate.annotations.Comment("댓글 ID")
     private Long id;
 
     @Column(nullable = false)
-    @org.hibernate.annotations.Comment("댓글 내용")
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    @org.hibernate.annotations.Comment("회원 FK")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
-    @org.hibernate.annotations.Comment("게시판 FK")
     private Board board;
 
     @Builder

--- a/src/main/java/org/hmanwon/domain/member/application/MemberService.java
+++ b/src/main/java/org/hmanwon/domain/member/application/MemberService.java
@@ -1,0 +1,22 @@
+package org.hmanwon.domain.member.application;
+
+import static org.hmanwon.domain.member.exception.MemberExceptionCode.NOT_FOUND_MEMBER;
+
+import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.member.dao.MemberRepository;
+import org.hmanwon.domain.member.entity.Member;
+import org.hmanwon.domain.member.exception.MemberException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+
+}

--- a/src/main/java/org/hmanwon/domain/member/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/member/entity/Member.java
@@ -15,7 +15,6 @@ import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hmanwon.domain.community.board.entity.Board;
 import org.hmanwon.domain.community.comment.entity.Comment;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -47,12 +46,17 @@ public class Member {
 
     @OneToMany(mappedBy = "member",
         cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
-    @Setter // 연간관계 메서드로 바꿔야 함
     private List<Board> boardList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member",
         cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
-    @Setter // 연간관계 메서드로 바꿔야 함
     private List<Comment> commentList = new ArrayList<>();
 
+    public void setBoardList(List<Board> boardList) {
+        this.boardList = boardList;
+    }
+
+    public void setCommentList(List<Comment> commentList) {
+        this.commentList = commentList;
+    }
 }

--- a/src/main/java/org/hmanwon/domain/member/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/member/entity/Member.java
@@ -5,26 +5,22 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.Min;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hmanwon.domain.community.board.entity.Board;
 import org.hmanwon.domain.community.comment.entity.Comment;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hmanwon.global.common.entity.BaseTimeEntity;
 
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/hmanwon/domain/member/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/member/entity/Member.java
@@ -28,19 +28,15 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @org.hibernate.annotations.Comment("회원 ID")
     private Long id;
 
     @Column(nullable = false)
-    @org.hibernate.annotations.Comment("회원 email")
     private String email;
 
     @Column(nullable = false)
-    @org.hibernate.annotations.Comment("회원 닉네임")
     private String nickName;
 
     @Column(nullable = false)
-    @org.hibernate.annotations.Comment("회원 포인트")
     @Min(0)
     private Long point;
 

--- a/src/main/java/org/hmanwon/domain/member/exception/MemberException.java
+++ b/src/main/java/org/hmanwon/domain/member/exception/MemberException.java
@@ -1,0 +1,11 @@
+package org.hmanwon.domain.member.exception;
+
+import org.hmanwon.global.common.exception.DefaultException;
+import org.hmanwon.global.common.exception.ExceptionCode;
+
+public class MemberException extends DefaultException {
+
+    public MemberException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+}

--- a/src/main/java/org/hmanwon/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/org/hmanwon/domain/member/exception/MemberExceptionCode.java
@@ -1,0 +1,20 @@
+package org.hmanwon.domain.member.exception;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hmanwon.global.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberExceptionCode implements ExceptionCode {
+
+    NOT_FOUND_MEMBER(INTERNAL_SERVER_ERROR, "Member Error 01", "사용자가 존재하지 않습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+}

--- a/src/main/java/org/hmanwon/domain/shop/dao/MenuRepository.java
+++ b/src/main/java/org/hmanwon/domain/shop/dao/MenuRepository.java
@@ -4,7 +4,6 @@ import org.hmanwon.domain.shop.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
 }

--- a/src/main/java/org/hmanwon/domain/shop/dao/SeoulGoodShopRepository.java
+++ b/src/main/java/org/hmanwon/domain/shop/dao/SeoulGoodShopRepository.java
@@ -5,7 +5,6 @@ import org.hmanwon.domain.shop.entity.SeoulGoodShop;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface SeoulGoodShopRepository extends JpaRepository<SeoulGoodShop, Long> {
     List<SeoulGoodShop> findByCategory(Long category);
     List<SeoulGoodShop> findByNameContains(String keyword);

--- a/src/main/java/org/hmanwon/domain/shop/entity/Menu.java
+++ b/src/main/java/org/hmanwon/domain/shop/entity/Menu.java
@@ -3,7 +3,6 @@ package org.hmanwon.domain.shop.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,15 +13,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hmanwon.global.common.entity.BaseTimeEntity;
 
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Menu {
+public class Menu extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/hmanwon/domain/shop/entity/Menu.java
+++ b/src/main/java/org/hmanwon/domain/shop/entity/Menu.java
@@ -14,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Comment;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -28,19 +27,15 @@ public class Menu {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @JsonIgnore
-    @Comment("가게 메뉴 id")
     private Long id;
 
     @Column(nullable = false)
-    @Comment("Menu 이름")
     private String menuName;
 
     @Column(nullable = false)
-    @Comment("Menu 가격")
     private Integer menuPrice;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seoul_good_shop_id")
-    @Comment("서울 착한 업소 FK")
     private SeoulGoodShop seoulGoodShop;
 }

--- a/src/main/java/org/hmanwon/domain/shop/entity/SeoulGoodShop.java
+++ b/src/main/java/org/hmanwon/domain/shop/entity/SeoulGoodShop.java
@@ -6,7 +6,6 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -17,11 +16,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/org/hmanwon/domain/shop/entity/SeoulGoodShop.java
+++ b/src/main/java/org/hmanwon/domain/shop/entity/SeoulGoodShop.java
@@ -16,7 +16,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -77,7 +76,9 @@ public class SeoulGoodShop {
 
     @OneToMany(mappedBy = "seoulGoodShop",
         cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, orphanRemoval = true)
-    @Setter
     private List<Menu> menuList = new ArrayList<>();
 
+    public void setMenuList(List<Menu> menuList) {
+        this.menuList = menuList;
+    }
 }

--- a/src/test/java/org/hmanwon/http_test/community/board/insert/board-create.http
+++ b/src/test/java/org/hmanwon/http_test/community/board/insert/board-create.http
@@ -1,0 +1,7 @@
+POST http://localhost:8080/api/boards?memberId=1
+Content-Type: application/json
+
+{
+  "title": "테스트 제목",
+  "content": "내용"
+}

--- a/src/test/java/org/hmanwon/http_test/community/board/select/board-getAll.http
+++ b/src/test/java/org/hmanwon/http_test/community/board/select/board-getAll.http
@@ -1,0 +1,2 @@
+GET http://localhost:8080/api/boards
+Accept: application/json

--- a/src/test/java/org/hmanwon/http_test/community/board/select/board-getDetail.http
+++ b/src/test/java/org/hmanwon/http_test/community/board/select/board-getDetail.http
@@ -1,0 +1,2 @@
+GET http://localhost:8080/api/boards/1
+Accept: application/json


### PR DESCRIPTION
# 변경 사항
1. 게시글의 CR 기능 구현 했습니다(상세 조회에서 댓글도 가져옴)
2. 연관 관계 Setter를 메서드로 변경하고, 기타 필요 없는 어노테이션을 삭제했습니다
3. 기본 Member
use happymanwon;
insert into member(email, nick_name, point, created_at,updated_at)
values('빅',  'erwf@anaeb',5000,'2023-11-13','2023-11-12');
 
# 확인 방법 (스크린샷 포함)
<img width="516" alt="image" src="https://github.com/happymanwon/Backend/assets/52107658/cf2ed0c7-bbf3-4462-9a74-1acaafd20d6d">
<img width="684" alt="image" src="https://github.com/happymanwon/Backend/assets/52107658/438896f8-ceb4-4a98-a956-50eadfe66016">
<img width="757" alt="image" src="https://github.com/happymanwon/Backend/assets/52107658/265236ff-192e-4a65-9d91-b1b77f1e9f89">
<img width="718" alt="image" src="https://github.com/happymanwon/Backend/assets/52107658/24a53c28-ab6b-4e12-b1c7-afd70655fd19">

# 추후 계획
**1. 변경된 기획 요구 사항에 맞게 게시판 형식을 바꿔야 합니다(거의 다 바꿔야 함, 제목도 없어야 하고 사진은 넣고 등등)**
2. DTO에 있는 @Setter 처리해야 할 것 같습니다, 특히 ResponseDto
3. Comment Controller 병합
4. ResponseEntity<ResponseDto> 형태인데 ResponseEntity까지는 안 해도 되지 않나 생각합니다
**5. 노션 API 문서에 작성해야 합니다**