### PR TITLE
[fix] responseDTO 수정

### DIFF
--- a/src/main/java/org/hmanwon/domain/community/comment/presentation/CommentRestController.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/presentation/CommentRestController.java
@@ -7,7 +7,7 @@ import org.hmanwon.domain.community.comment.dto.request.CommentRequestDto;
 import org.hmanwon.domain.community.comment.dto.request.CommentUpdateRequestsDto;
 import org.hmanwon.domain.community.comment.dto.response.CommentResponseDto;
 import org.hmanwon.global.common.dto.ResponseDTO;
-import org.springframework.http.HttpStatus;
+import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -25,28 +25,35 @@ public class CommentRestController {
     private final CommentService commentService;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO<CommentResponseDto>> postComment(
-        @Valid @RequestBody CommentRequestDto commentRequestDTO) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ResponseDTO.res(HttpStatus.CREATED,
-                commentService.createComment(1L, commentRequestDTO), "성공적으로 댓글을 생성했습니다."));
+    public ResponseEntity<DataBody<CommentResponseDto>> postComment(
+        @Valid @RequestBody CommentRequestDto commentRequestDTO
+    ) {
+        return ResponseDTO.created(
+                commentService.createComment(1L, commentRequestDTO),
+                "성공적으로 댓글을 생성했습니다."
+        );
+
+
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<ResponseDTO<CommentResponseDto>> updateCommentContent(
+    public ResponseEntity<DataBody<CommentResponseDto>> updateCommentContent(
         @PathVariable Long commentId,
-        @Valid @RequestBody CommentUpdateRequestsDto commentUpdateRequestsDto) {
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(ResponseDTO.res(HttpStatus.OK,
+        @Valid @RequestBody CommentUpdateRequestsDto commentUpdateRequestsDto
+    ) {
+        return ResponseDTO.ok(
                 commentService.updateContent(1L, commentId, commentUpdateRequestsDto),
-                "성공적으로 댓글을 수정했습니다."));
+                "성공적으로 댓글을 수정했습니다."
+        );
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ResponseDTO<CommentResponseDto>> deleteComment(
-        @PathVariable Long commentId) {
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(ResponseDTO.res(HttpStatus.OK,
-                commentService.deleteCommentById(1L, commentId), "성공적으로 댓글을 삭제했습니다."));
+    public ResponseEntity<DataBody<CommentResponseDto>> deleteComment(
+        @PathVariable Long commentId
+    ) {
+        return ResponseDTO.ok(
+                commentService.deleteCommentById(1L, commentId),
+                "성공적으로 댓글을 삭제했습니다."
+        );
     }
 }

--- a/src/main/java/org/hmanwon/domain/shop/presentation/ShopController.java
+++ b/src/main/java/org/hmanwon/domain/shop/presentation/ShopController.java
@@ -8,7 +8,8 @@ import org.hmanwon.domain.shop.dto.SeoulGoodShopResponse;
 import org.hmanwon.domain.shop.exception.ShopException;
 import org.hmanwon.domain.shop.exception.ShopExceptionCode;
 import org.hmanwon.global.common.dto.ResponseDTO;
-import org.springframework.http.HttpStatus;
+import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,34 +24,38 @@ public class ShopController {
     private final ShopService shopService;
 
     @GetMapping("")
-    public ResponseDTO<List<SeoulGoodShopResponse>> getShopsByCategoryAndLocalCode(
+    public ResponseEntity<DataBody<List<SeoulGoodShopResponse>>> getShopsByCategoryAndLocalCode(
             @RequestParam(name = "categoryId", required = false) final Long categoryId,
             @RequestParam(name = "localCode", required = false) final Long localCode
     ) {
         if (categoryId != null && categoryId > 8) {
             throw new ShopException(ShopExceptionCode.CATEGORY_BAD_REQUEST);
         }
-        return ResponseDTO.res(HttpStatus.OK,
-                shopService.getShopsByCategoryAndLocalCode(
-                    categoryId, localCode
-                ),
-                "착한 가격 업소 조회 완료"
-        );
+        return ResponseDTO.ok(
+                        shopService.getShopsByCategoryAndLocalCode(categoryId, localCode),
+                        "착한 가격 업소 조회 완료"
+                );
     }
 
 
     @GetMapping("/{shopId}")
-    public List<SeoulGoodShopDetailResponse> getShopDetail(
+    public ResponseEntity<DataBody<List<SeoulGoodShopDetailResponse>>> getShopDetail(
         @PathVariable final Long shopId
     ) {
-        return shopService.getShopDetail(shopId);
+        return ResponseDTO.ok(
+                shopService.getShopDetail(shopId),
+                "착한 가격 업소 상세 조회 완료"
+        );
     }
 
     @GetMapping("/search")
-    public List<SeoulGoodShopResponse> searchShopByKeyword(
+    public ResponseEntity<DataBody<List<SeoulGoodShopResponse>>> searchShopByKeyword(
         @RequestParam(name = "keyword") final String keyword
     ) {
-        return shopService.searchShopByKeyword(keyword);
+        return ResponseDTO.ok(
+                shopService.searchShopByKeyword(keyword),
+                "착한 가격 업소 검색 완료"
+        );
     }
 
 }

--- a/src/main/java/org/hmanwon/global/common/dto/ResponseDTO.java
+++ b/src/main/java/org/hmanwon/global/common/dto/ResponseDTO.java
@@ -1,51 +1,116 @@
 package org.hmanwon.global.common.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 
 @Getter
 @Setter
 @ToString
 @Builder
-public class ResponseDTO<T> {
+public class ResponseDTO {
 
-    private int code;
-    private String message;
-    private T data;
+    private DataBody body;
 
     /**
-     * HTTP 상태 코드, 데이터, 그리고 메시지를 이용하여 ResponseDTO 객체를 생성하는 메서드
-     *
-     * @param httpStatus HTTP 상태 코드
-     * @param data       응답 데이터
-     * @param message    응답 메시지
-     * @param <T>        데이터의 제네릭 타입
-     * @return 생성된 ResponseDTO 객체
+     * 상태 코드 : created (201) : Post, Put
+     * @param data
+     * @param message
+     * @return
+     * @param <T>
      */
-    public static <T> ResponseDTO<T> res(HttpStatus httpStatus, @Nullable T data, String message) {
-        return ResponseDTO.<T>builder()
-            .code(httpStatus.value())
-            .message(message)
-            .data(data)
-            .build();
+    public static <T> ResponseEntity<DataBody<T>> created(@Nullable T data, String message) {
+        return  ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new DataBody<T>(data, message));
     }
 
     /**
-     * HTTP 상태 코드와 메시지를 이용하여 ResponseDTO 객체를 생성하는 메서드
-     *
-     * @param httpStatus HTTP 상태 코드
-     * @param message    응답 메시지
-     * @param <T>        데이터의 제네릭 타입
-     * @return 생성된 ResponseDTO 객체
+     * 상태 코드 : created (201)
+     * @param message
+     * @return
+     * @param
      */
-    public static <T> ResponseDTO<T> res(HttpStatus httpStatus, String message) {
-        return ResponseDTO.<T>builder()
-            .code(httpStatus.value())
-            .message(message)
-            .build();
+    public static <T> ResponseEntity<DataBody<T>> created(String message) {
+        return  ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new DataBody<T>(message));
+    }
+
+    /**
+     * 상태 코드 : ok (200)
+     * @param data
+     * @param message
+     * @return
+     * @param <T>
+     */
+    public static <T> ResponseEntity<DataBody<T>> ok(@Nullable T data, String message) {
+        return  ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new DataBody<T>(data, message));
+    }
+
+    /**
+     * 상태 코드 : ok (200)
+     * @param message
+     * @return
+     * @param <T>
+     */
+    public static <T> ResponseEntity<DataBody<T>> ok(String message) {
+        return  ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new DataBody<T>(message));
+    }
+
+    /**
+     * 상태 코드 : accepted (202) : 클라이언트의 요청은 정상적이나, 서버가 아직 요청을 완료하지 못했다.
+     * @param data
+     * @param message
+     * @return
+     * @param <T>
+     */
+    public static <T> ResponseEntity<DataBody<T>> accepted(@Nullable T data, String message) {
+        return  ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(new DataBody<T>(data, message));
+    }
+
+    /**
+     * 상태 코드 : accepted (202) : 클라이언트의 요청은 정상적이나, 서버가 아직 요청을 완료하지 못했다.
+     * @param message
+     * @return
+     * @param <T>
+     */
+    public static <T> ResponseEntity<T> accepted(String message) {
+        return (ResponseEntity<T>) ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(new DataBody<T>(message));
+    }
+
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class DataBody<T> {
+        /**
+         * HTTP 상태 코드, 데이터, 그리고 메시지를 이용하여 ResponseBody 객체를 생성하는 메서드
+         *
+         * @param data       응답 데이터
+         * @param message    응답 메시지
+         * @param <T>        데이터의 제네릭 타입
+         * @return 생성된 ResponseBody 객체
+         */
+
+        private T data;
+        private String message;
+
+        public DataBody(String message) {
+            this.message = message;
+        }
     }
 }


### PR DESCRIPTION
# 반영 브랜치
feature/fix-controller

# 변경 사항
responseDTO를 개선했습니다. 

# 확인 방법 (스크린샷 포함)
다음과 같이 사용해주시면 됩니다. 
ResponseBody는 어노테이션에 걸려서, DataBody로 바꿨습니다. 
![image](https://github.com/happymanwon/Backend/assets/59862752/5b98135f-ce7a-45d8-8f71-bcc5095e8a7a)

created, ok, accepted 3가지
data 있는 버전, data 없이 message만 있는 버전 총 6가지 만들었습니다. 
