### PR TITLE
Feature/member api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,10 @@ dependencies {
 	implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
 	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
 	implementation group: 'org.json', name: 'json', version: '20180813'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
-
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
-//	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-//	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-//	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-//	testImplementation 'org.springframework.security:spring-security-test'
 
 	// Mockito dependencies
 	testImplementation 'org.mockito:mockito-core:4.1.0'

--- a/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
+++ b/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
@@ -1,0 +1,156 @@
+package org.hmanwon.domain.auth.application;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.auth.dto.AuthLoginResponse;
+import org.hmanwon.domain.member.application.MemberService;
+import org.hmanwon.domain.member.dto.response.MemberResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberService memberService;
+    private final JwtProvider jwtProvider;
+
+    @Value("${kakao.rest_api_key}")
+    String clientId;
+    String redirectURL = "http://localhost:8080/api/auth/login/kakao";
+
+    public AuthLoginResponse kakaoLogin(String kakaoAuthorizationCode) {
+        //인가코드 받아서 카카오 토큰 발급
+        String kakaoAccessToken = getKakaoToken(kakaoAuthorizationCode);
+
+        //카카오 토큰으로 유저 정보 조회
+        HashMap<String, Object> memberInfoFromKakao = getMemberInfoFromKakao(kakaoAccessToken);
+
+        String kakaoEmail = String.valueOf(memberInfoFromKakao.get("email"));
+
+        MemberResponse memberResponse;
+        if (!memberService.checkEmail(kakaoEmail)) { //회원가입 대상
+            memberResponse = memberService.addMember(memberInfoFromKakao);
+        } else {
+            memberResponse = memberService.findByEmail(kakaoEmail);
+        }
+
+        //서비스 토큰 발급
+        String serviceAccessToken = jwtProvider.createAccessToken(kakaoEmail,
+            memberResponse.memberId());
+        String serviceRefreshToken = jwtProvider.createRefreshToken();
+
+        return AuthLoginResponse.builder()
+            .accessToken(serviceAccessToken)
+            .refreshToken(serviceRefreshToken)
+            .memberId(memberResponse.memberId())
+            .nickname(memberResponse.nickname())
+            .build();
+    }
+
+    public String getKakaoToken(String code) {
+
+        String accessToken = "";
+        String refreshToken = "";
+        String requestUrl = "https://kauth.kakao.com/oauth/token";
+
+        try {
+            URL url = new URL(requestUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+            StringBuilder sb = new StringBuilder();
+            sb.append("grant_type=authorization_code");
+            sb.append("&client_id=" + clientId);
+            sb.append("&redirect_uri=" + redirectURL);
+            sb.append("&code=" + code);
+            bw.write(sb.toString());
+            bw.flush();
+
+            int responseCode = conn.getResponseCode();
+            System.out.println("responseCode = " + responseCode);
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+
+            accessToken = element.getAsJsonObject().get("access_token").getAsString();
+            refreshToken = element.getAsJsonObject().get("refresh_token").getAsString();
+
+            System.out.println("accessToken = " + accessToken);
+            System.out.println("refreshToken = " + refreshToken);
+
+            br.close();
+            bw.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return accessToken;
+    }
+
+
+    public HashMap<String, Object> getMemberInfoFromKakao(String accessToken) {
+        HashMap<String, Object> memberInfo = new HashMap<String, Object>();
+
+        String requestURL = "https://kapi.kakao.com/v2/user/me";
+
+        try {
+            URL url = new URL(requestURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+            int responseCode = conn.getResponseCode();
+            System.out.println("responseCode = " + responseCode);
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            System.out.println("responseBody = " + result);
+
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+
+            JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
+            JsonObject kakaoAccount = element.getAsJsonObject().get("kakao_account")
+                .getAsJsonObject();
+
+            String nickname = properties.getAsJsonObject().get("nickname").getAsString();
+            String email = kakaoAccount.getAsJsonObject().get("email").getAsString();
+
+            memberInfo.put("nickname", nickname);
+            memberInfo.put("email", email);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return memberInfo;
+    }
+}

--- a/src/main/java/org/hmanwon/domain/auth/application/JwtProvider.java
+++ b/src/main/java/org/hmanwon/domain/auth/application/JwtProvider.java
@@ -1,0 +1,83 @@
+package org.hmanwon.domain.auth.application;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtProvider {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+    @Value("${jwt.accessTokenValidTime}")
+    private long accessTokenValidTime;
+    @Value("${jwt.refreshTokenValidTime}")
+    private long refreshTokenValidTime;
+
+    public String createAccessToken(String email, Long memberId) {
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + accessTokenValidTime);
+
+        return Jwts.builder()
+            .setSubject(email)
+            .claim("email", email)
+            .claim("memberId", memberId)
+            .setIssuedAt(now)
+            .setExpiration(expiryDate)
+            .signWith(SignatureAlgorithm.HS512, secretKey)
+            .compact();
+    }
+
+    public String createRefreshToken() {
+        Date now = new Date();
+
+        return Jwts.builder()
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + refreshTokenValidTime))
+            .signWith(SignatureAlgorithm.HS512, secretKey)
+            .compact();
+    }
+
+    public String getEmailFromToken(String token) {
+        Claims claims = Jwts.parser()
+            .setSigningKey(secretKey)
+            .parseClaimsJws(token)
+            .getBody();
+        return claims.getSubject();
+    }
+
+    public String getMemberIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+            .setSigningKey(secretKey)
+            .parseClaimsJws(token).getBody();
+        return (String) claims.get("memberId");
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token).getBody();
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("JWT 토큰이 만료되었습니다.");
+        } catch (UnsupportedJwtException e) {
+            throw new JwtException("지원되지 않는 JWT 토큰입니다.");
+        } catch (MalformedJwtException e) {
+            throw new JwtException("올바르게 구성되지 않은 JWT 토큰입니다.");
+        } catch (SignatureException e) {
+            throw new JwtException("유효하지 않은 JWT 서명입니다.");
+        } catch (IllegalArgumentException e) {
+            throw new JwtException("JWT 클레임이 비어있습니다.");
+        }
+    }
+}

--- a/src/main/java/org/hmanwon/domain/auth/dto/AuthLoginResponse.java
+++ b/src/main/java/org/hmanwon/domain/auth/dto/AuthLoginResponse.java
@@ -1,0 +1,14 @@
+package org.hmanwon.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AuthLoginResponse(
+    String accessToken,
+    String refreshToken,
+    Long memberId,
+    String nickname
+
+) {
+
+}

--- a/src/main/java/org/hmanwon/domain/auth/presentation/AuthController.java
+++ b/src/main/java/org/hmanwon/domain/auth/presentation/AuthController.java
@@ -1,0 +1,25 @@
+package org.hmanwon.domain.auth.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.auth.application.AuthService;
+import org.hmanwon.domain.auth.dto.AuthLoginResponse;
+import org.hmanwon.global.common.dto.ResponseDTO;
+import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login/kakao")
+    public ResponseEntity<DataBody<AuthLoginResponse>> KakaoLogin(@RequestParam String code) {
+        return ResponseDTO.ok(authService.kakaoLogin(code), "카카오로그인이 정상적으로 완료되었습니다.");
+    }
+}

--- a/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
+++ b/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
@@ -11,6 +11,7 @@ import org.hmanwon.domain.community.board.dto.response.BoardDetailResponse;
 import org.hmanwon.domain.community.board.dto.response.BoardResponse;
 import org.hmanwon.domain.community.board.entity.Board;
 import org.hmanwon.domain.community.board.exception.BoardException;
+import org.hmanwon.domain.community.comment.entity.Comment;
 import org.hmanwon.domain.member.application.MemberService;
 import org.hmanwon.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
@@ -41,6 +42,19 @@ public class BoardService {
         Board board = Board.of(
             boardWriteRequest.content(), member
         );
-        return boardRepository.save(board);
+        Board newBoard = boardRepository.save(board);
+        memberService.updateBoardListByMember(member, board);
+        return newBoard;
+    }
+
+    public Board findBoardById(Long boardId) {
+        return boardRepository.findById(boardId).orElseThrow(()-> new BoardException(NOT_FOUND_BOARD));
+    }
+
+    public void updateCommentList(Board board, Comment comment) {
+        List<Comment> comments = board.getCommentList();
+        comments.add(comment);
+        board.setCommentList(comments);
+        boardRepository.save(board);
     }
 }

--- a/src/main/java/org/hmanwon/domain/community/board/exception/BoardExceptionCode.java
+++ b/src/main/java/org/hmanwon/domain/community/board/exception/BoardExceptionCode.java
@@ -1,6 +1,6 @@
 package org.hmanwon.domain.community.board.exception;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum BoardExceptionCode implements ExceptionCode {
 
-    NOT_FOUND_BOARD(INTERNAL_SERVER_ERROR, "Board Error 01", "게시글이 존재하지 않습니다.")
+    NOT_FOUND_BOARD(NOT_FOUND, "Board Error 01", "게시글이 존재하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/hmanwon/domain/community/comment/exception/CommentExceptionCode.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/exception/CommentExceptionCode.java
@@ -1,7 +1,6 @@
 package org.hmanwon.domain.community.comment.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +11,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum CommentExceptionCode implements ExceptionCode {
 
-    NOT_FOUND_COMMENT(BAD_REQUEST, "Comment Error 01", "댓글이 존재하지 않습니다.")
+    NOT_FOUND_COMMENT(NOT_FOUND, "Comment Error 01", "댓글이 존재하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/hmanwon/domain/member/application/MemberService.java
+++ b/src/main/java/org/hmanwon/domain/member/application/MemberService.java
@@ -112,4 +112,16 @@ public class MemberService {
     public boolean checkEmail(String email) {
         return memberRepository.existsByEmail(email);
     }
+
+    public void updateBoardListByMember(Member member, Board board) {
+        List<Board> boards = member.getBoardList();
+        boards.add(board);
+        memberRepository.save(member);
+    }
+
+    public void updateCommentListByMember(Member member, Comment comment) {
+        List<Comment> comments = member.getCommentList();
+        comments.add(comment);
+        memberRepository.save(member);
+    }
 }

--- a/src/main/java/org/hmanwon/domain/member/application/MemberService.java
+++ b/src/main/java/org/hmanwon/domain/member/application/MemberService.java
@@ -8,8 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.hmanwon.domain.community.board.entity.Board;
 import org.hmanwon.domain.community.comment.entity.Comment;
 import org.hmanwon.domain.member.dao.MemberRepository;
-import org.hmanwon.domain.member.dto.MyBoardsResponseDto;
-import org.hmanwon.domain.member.dto.MyCommentResponseDto;
+import org.hmanwon.domain.member.dto.response.MyBoardsResponseDto;
+import org.hmanwon.domain.member.dto.response.MyCommentResponseDto;
+import org.hmanwon.domain.member.dto.response.NicknameResponse;
 import org.hmanwon.domain.member.entity.Member;
 import org.hmanwon.domain.member.exception.MemberException;
 import org.springframework.stereotype.Service;
@@ -66,5 +67,15 @@ public class MemberService {
     public Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+
+    public NicknameResponse findNickname(String nickname) {
+        NicknameResponse nicknameResponse;
+        if (memberRepository.existsByNickname(nickname)) {
+            nicknameResponse = NicknameResponse.builder().nickname(nickname).exists(true).build();
+        } else {
+            nicknameResponse = NicknameResponse.builder().nickname(nickname).exists(false).build();
+        }
+        return nicknameResponse;
     }
 }

--- a/src/main/java/org/hmanwon/domain/member/application/MemberService.java
+++ b/src/main/java/org/hmanwon/domain/member/application/MemberService.java
@@ -3,11 +3,13 @@ package org.hmanwon.domain.member.application;
 import static org.hmanwon.domain.member.exception.MemberExceptionCode.NOT_FOUND_MEMBER;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hmanwon.domain.community.board.entity.Board;
 import org.hmanwon.domain.community.comment.entity.Comment;
 import org.hmanwon.domain.member.dao.MemberRepository;
+import org.hmanwon.domain.member.dto.response.MemberResponse;
 import org.hmanwon.domain.member.dto.response.MyBoardsResponseDto;
 import org.hmanwon.domain.member.dto.response.MyCommentResponseDto;
 import org.hmanwon.domain.member.dto.response.NicknameResponse;
@@ -69,6 +71,16 @@ public class MemberService {
             .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
     }
 
+    public MemberResponse findByEmail(String email) {
+        Member member = memberRepository.findByEmail(email);
+        return MemberResponse.builder()
+            .memberId(member.getId())
+            .email(member.getEmail())
+            .nickname(member.getNickName())
+            .point(member.getPoint())
+            .build();
+    }
+
     public NicknameResponse findNickname(String nickname) {
         NicknameResponse nicknameResponse;
         if (memberRepository.existsByNickname(nickname)) {
@@ -77,5 +89,31 @@ public class MemberService {
             nicknameResponse = NicknameResponse.builder().nickname(nickname).exists(false).build();
         }
         return nicknameResponse;
+    }
+
+    public boolean checkEmail(String email) {
+        return memberRepository.existsByEmail(email);
+    }
+
+    public MemberResponse addMember(HashMap<String, Object> memberInfoByKakao) {
+        String email = String.valueOf(memberInfoByKakao.get("email"));
+        String nickname = String.valueOf(memberInfoByKakao.get("nickname"));
+
+        Member member = Member.builder()
+            .email(email)
+            .nickName(nickname)
+            .point(0L)
+            .commentList(new ArrayList<>())
+            .boardList(new ArrayList<>())
+            .build();
+
+        memberRepository.save(member);
+
+        return MemberResponse.builder()
+            .memberId(member.getId())
+            .email(member.getEmail())
+            .nickname(member.getNickName())
+            .point(member.getPoint())
+            .build();
     }
 }

--- a/src/main/java/org/hmanwon/domain/member/application/MemberService.java
+++ b/src/main/java/org/hmanwon/domain/member/application/MemberService.java
@@ -1,0 +1,70 @@
+package org.hmanwon.domain.member.application;
+
+import static org.hmanwon.domain.member.exception.MemberExceptionCode.NOT_FOUND_MEMBER;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.community.board.entity.Board;
+import org.hmanwon.domain.community.comment.entity.Comment;
+import org.hmanwon.domain.member.dao.MemberRepository;
+import org.hmanwon.domain.member.dto.MyBoardsResponseDto;
+import org.hmanwon.domain.member.dto.MyCommentResponseDto;
+import org.hmanwon.domain.member.entity.Member;
+import org.hmanwon.domain.member.exception.MemberException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public List<MyCommentResponseDto> findCommentsByMember(Long memberId) {
+
+        Member member = findMemberById(memberId);
+        List<Comment> comments = member.getCommentList();
+        List<MyCommentResponseDto> myCommentResponseDtoList = new ArrayList<>();
+        for (Comment comment : comments) {
+            MyCommentResponseDto myCommentResponseDto = MyCommentResponseDto.builder()
+                .boardId(comment.getBoard().getId())
+                .boardTitle(comment.getBoard().getTitle())
+                .memberId(memberId)
+                .nickname(member.getNickName())
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+            myCommentResponseDtoList.add(myCommentResponseDto);
+        }
+        return myCommentResponseDtoList;
+    }
+
+    public List<MyBoardsResponseDto> findBoardsByMember(Long memberId) {
+
+        Member member = findMemberById(memberId);
+        List<Board> boards = member.getBoardList();
+        List<MyBoardsResponseDto> myBoardsResponseDtoList = new ArrayList<>();
+
+        for (Board board : boards) {
+            MyBoardsResponseDto myBoardsResponseDto = MyBoardsResponseDto.builder()
+                .boardId(board.getId())
+                .boardTitle(board.getTitle())
+                .memberId(memberId)
+                .nickname(member.getNickName())
+                .createAt(board.getCreatedAt())
+                .updateAt(board.getUpdatedAt())
+                .build();
+            myBoardsResponseDtoList.add(myBoardsResponseDto);
+        }
+        return myBoardsResponseDtoList;
+    }
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+}

--- a/src/main/java/org/hmanwon/domain/member/dao/MemberRepository.java
+++ b/src/main/java/org/hmanwon/domain/member/dao/MemberRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
+    Member findByEmail(String email);
 }

--- a/src/main/java/org/hmanwon/domain/member/dao/MemberRepository.java
+++ b/src/main/java/org/hmanwon/domain/member/dao/MemberRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/hmanwon/domain/member/dto/MyBoardsResponseDto.java
+++ b/src/main/java/org/hmanwon/domain/member/dto/MyBoardsResponseDto.java
@@ -1,0 +1,17 @@
+package org.hmanwon.domain.member.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record MyBoardsResponseDto(
+    Long boardId,
+    String boardTitle,
+    Long memberId,
+    String nickname,
+    LocalDateTime createAt,
+    LocalDateTime updateAt
+
+) {
+
+}

--- a/src/main/java/org/hmanwon/domain/member/dto/MyCommentResponseDto.java
+++ b/src/main/java/org/hmanwon/domain/member/dto/MyCommentResponseDto.java
@@ -1,0 +1,18 @@
+package org.hmanwon.domain.member.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record MyCommentResponseDto(
+    Long boardId,
+    String boardTitle,
+    Long memberId,
+    String nickname,
+    Long commentId,
+    String content,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/org/hmanwon/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/org/hmanwon/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,14 @@
+package org.hmanwon.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MemberResponse(
+    Long memberId,
+    String email,
+    String nickname,
+    Long point
+
+) {
+
+}

--- a/src/main/java/org/hmanwon/domain/member/dto/response/MyBoardsResponseDto.java
+++ b/src/main/java/org/hmanwon/domain/member/dto/response/MyBoardsResponseDto.java
@@ -1,4 +1,4 @@
-package org.hmanwon.domain.member.dto;
+package org.hmanwon.domain.member.dto.response;
 
 import java.time.LocalDateTime;
 import lombok.Builder;

--- a/src/main/java/org/hmanwon/domain/member/dto/response/MyCommentResponseDto.java
+++ b/src/main/java/org/hmanwon/domain/member/dto/response/MyCommentResponseDto.java
@@ -1,4 +1,4 @@
-package org.hmanwon.domain.member.dto;
+package org.hmanwon.domain.member.dto.response;
 
 import java.time.LocalDateTime;
 import lombok.Builder;

--- a/src/main/java/org/hmanwon/domain/member/dto/response/NicknameResponse.java
+++ b/src/main/java/org/hmanwon/domain/member/dto/response/NicknameResponse.java
@@ -1,0 +1,11 @@
+package org.hmanwon.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record NicknameResponse(
+    String nickname,
+    Boolean exists
+) {
+
+}

--- a/src/main/java/org/hmanwon/domain/member/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/member/entity/Member.java
@@ -53,6 +53,10 @@ public class Member extends BaseTimeEntity {
         cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member",
+        cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<PurchaseHistory> purchaseHistoryList = new ArrayList<>();
+
     public void setBoardList(List<Board> boardList) {
         this.boardList = boardList;
     }
@@ -60,8 +64,4 @@ public class Member extends BaseTimeEntity {
     public void setCommentList(List<Comment> commentList) {
         this.commentList = commentList;
     }
-
-    @OneToMany(mappedBy = "member",
-        cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<PurchaseHistory> purchaseHistoryList = new ArrayList<>();
 }

--- a/src/main/java/org/hmanwon/domain/member/entity/Member.java
+++ b/src/main/java/org/hmanwon/domain/member/entity/Member.java
@@ -13,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,6 +24,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Member {

--- a/src/main/java/org/hmanwon/domain/member/exception/MemberException.java
+++ b/src/main/java/org/hmanwon/domain/member/exception/MemberException.java
@@ -1,0 +1,11 @@
+package org.hmanwon.domain.member.exception;
+
+import org.hmanwon.global.common.exception.DefaultException;
+import org.hmanwon.global.common.exception.ExceptionCode;
+
+public class MemberException extends DefaultException {
+
+    public MemberException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+}

--- a/src/main/java/org/hmanwon/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/org/hmanwon/domain/member/exception/MemberExceptionCode.java
@@ -1,0 +1,19 @@
+package org.hmanwon.domain.member.exception;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hmanwon.global.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberExceptionCode implements ExceptionCode {
+
+    NOT_FOUND_MEMBER(INTERNAL_SERVER_ERROR, "Member Error 01", "회원 정보가 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+}

--- a/src/main/java/org/hmanwon/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/org/hmanwon/domain/member/exception/MemberExceptionCode.java
@@ -1,6 +1,6 @@
 package org.hmanwon.domain.member.exception;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberExceptionCode implements ExceptionCode {
 
-    NOT_FOUND_MEMBER(INTERNAL_SERVER_ERROR, "Member Error 01", "회원 정보가 존재하지 않습니다.")
+    NOT_FOUND_MEMBER(NOT_FOUND, "Member Error 01", "회원 정보가 존재하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
@@ -1,0 +1,34 @@
+package org.hmanwon.domain.member.presentation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.member.application.MemberService;
+import org.hmanwon.domain.member.dto.MyBoardsResponseDto;
+import org.hmanwon.domain.member.dto.MyCommentResponseDto;
+import org.hmanwon.global.common.dto.ResponseDTO;
+import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/comments")
+    public ResponseEntity<DataBody<List<MyCommentResponseDto>>> getCommentsByMember() {
+        Long memberId = 1L;
+        return ResponseDTO.ok(memberService.findCommentsByMember(memberId), "내 댓글 목록을 조회했습니다.");
+    }
+
+    @GetMapping("/boards")
+    public ResponseEntity<DataBody<List<MyBoardsResponseDto>>> getBoardsByMember() {
+        Long memberId = 1L;
+        return ResponseDTO.ok(memberService.findBoardsByMember(memberId), "내 게시글 목록을 조회했습니다.");
+    }
+
+}

--- a/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
@@ -1,15 +1,18 @@
 package org.hmanwon.domain.member.presentation;
 
 import java.util.List;
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.hmanwon.domain.member.application.MemberService;
-import org.hmanwon.domain.member.dto.MyBoardsResponseDto;
-import org.hmanwon.domain.member.dto.MyCommentResponseDto;
+import org.hmanwon.domain.member.dto.response.MyBoardsResponseDto;
+import org.hmanwon.domain.member.dto.response.MyCommentResponseDto;
+import org.hmanwon.domain.member.dto.response.NicknameResponse;
 import org.hmanwon.global.common.dto.ResponseDTO;
 import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,6 +21,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+
+    @GetMapping("/nickname")
+    public ResponseEntity<DataBody<NicknameResponse>> getNickname(@RequestParam @NotBlank String nickname) {
+        return ResponseDTO.ok(memberService.findNickname(nickname), "닉네임 존재여부를 조회했습니다.");
+    }
 
     @GetMapping("/comments")
     public ResponseEntity<DataBody<List<MyCommentResponseDto>>> getCommentsByMember() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,7 @@ server:
 
 kakao:
   rest_api_key : KakaoAK 2d10cd365cbf8f56eda4e243e68f505e
+jwt:
+  secretKey: hmanwonsecretkey
+  accessTokenValidTime: 86400000
+  refreshTokenValidTime: 604800000


### PR DESCRIPTION
# 반영 브랜치

# 변경 사항
- 닉네임 조회 api 
- 내가 쓴 게시글 목록 조회 api
- 내가 쓴 댓글 목록 조회 api
- 소셜 로그인 (회원가입 또는 로그인) api 

# 전달 사항
- 회원가입 시, 닉네임 설정하는 로직x. 카카오의 닉네임을 바로 가져옴. 
- 카카오 rest api key 수정 필요 
- yml 의 kakao 관련 key secret으로 옮길지 논의

# 확인 방법 (스크린샷 포함)
-  테스트 스샷 첨부 예정