### PR TITLE
refactor: 닉네임 유효성 검증 및 응답 메세지 수정

### DIFF
--- a/src/main/java/org/hmanwon/domain/auth/presentation/AuthController.java
+++ b/src/main/java/org/hmanwon/domain/auth/presentation/AuthController.java
@@ -20,6 +20,6 @@ public class AuthController {
 
     @PostMapping("/login/kakao")
     public ResponseEntity<DataBody<AuthLoginResponse>> KakaoLogin(@RequestParam String code) {
-        return ResponseDTO.ok(authService.kakaoLogin(code), "카카오로그인이 정상적으로 완료되었습니다.");
+        return ResponseDTO.ok(authService.kakaoLogin(code), "카카오 로그인 완료");
     }
 }

--- a/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
+++ b/src/main/java/org/hmanwon/domain/community/board/application/BoardService.java
@@ -55,6 +55,5 @@ public class BoardService {
         List<Comment> comments = board.getCommentList();
         comments.add(comment);
         board.setCommentList(comments);
-        boardRepository.save(board);
     }
 }

--- a/src/main/java/org/hmanwon/domain/community/comment/application/CommentService.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/application/CommentService.java
@@ -1,5 +1,7 @@
 package org.hmanwon.domain.community.comment.application;
 
+import static org.hmanwon.domain.community.comment.exception.CommentExceptionCode.NOT_FOUND_COMMENT;
+
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.hmanwon.domain.community.board.application.BoardService;
@@ -9,6 +11,7 @@ import org.hmanwon.domain.community.comment.dto.request.CommentRequestDto;
 import org.hmanwon.domain.community.comment.dto.request.CommentUpdateRequestsDto;
 import org.hmanwon.domain.community.comment.dto.response.CommentResponseDto;
 import org.hmanwon.domain.community.comment.entity.Comment;
+import org.hmanwon.domain.community.comment.exception.CommentException;
 import org.hmanwon.domain.member.application.MemberService;
 import org.hmanwon.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
@@ -21,6 +24,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final BoardService boardService;
     private final MemberService memberService;
+
     /***
      * 댓글 생성
      * @param memberId 회원 ID
@@ -62,7 +66,8 @@ public class CommentService {
      * @return 댓글 Entity
      */
     public Comment getComment(Long commentId) {
-        return (Comment) commentRepository.findById(commentId).orElseThrow();
+        return commentRepository.findById(commentId)
+            .orElseThrow(() -> new CommentException(NOT_FOUND_COMMENT));
     }
 
     /***

--- a/src/main/java/org/hmanwon/domain/community/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/dto/request/CommentRequestDto.java
@@ -4,9 +4,9 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 public record CommentRequestDto(
-    @NotNull
+    @NotNull(message = "게시글 ID를 입력하세요.")
     Long boardId,
-    @NotBlank
+    @NotBlank(message = "게시글 내용을 입력하세요.")
     String content
 ) {
 }

--- a/src/main/java/org/hmanwon/domain/community/comment/dto/request/CommentUpdateRequestsDto.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/dto/request/CommentUpdateRequestsDto.java
@@ -3,7 +3,7 @@ package org.hmanwon.domain.community.comment.dto.request;
 import javax.validation.constraints.NotBlank;
 
 public record CommentUpdateRequestsDto(
-    @NotBlank
+    @NotBlank(message = "게시글 내용을 입력하세요.")
     String Content
 ) {
 

--- a/src/main/java/org/hmanwon/domain/community/comment/presentation/CommentController.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/presentation/CommentController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/comments")
-public class CommentRestController {
+public class CommentController {
 
     private final CommentService commentService;
 

--- a/src/main/java/org/hmanwon/domain/community/comment/presentation/CommentRestController.java
+++ b/src/main/java/org/hmanwon/domain/community/comment/presentation/CommentRestController.java
@@ -30,7 +30,7 @@ public class CommentRestController {
     ) {
         return ResponseDTO.created(
                 commentService.createComment(1L, commentRequestDTO),
-                "성공적으로 댓글을 생성했습니다."
+                "댓글 생성 완료"
         );
 
 
@@ -43,7 +43,7 @@ public class CommentRestController {
     ) {
         return ResponseDTO.ok(
                 commentService.updateContent(1L, commentId, commentUpdateRequestsDto),
-                "성공적으로 댓글을 수정했습니다."
+                "댓글 수정 완료"
         );
     }
 
@@ -53,7 +53,7 @@ public class CommentRestController {
     ) {
         return ResponseDTO.ok(
                 commentService.deleteCommentById(1L, commentId),
-                "성공적으로 댓글을 삭제했습니다."
+                "댓글 삭제 완료"
         );
     }
 }

--- a/src/main/java/org/hmanwon/domain/member/application/MemberService.java
+++ b/src/main/java/org/hmanwon/domain/member/application/MemberService.java
@@ -116,12 +116,12 @@ public class MemberService {
     public void updateBoardListByMember(Member member, Board board) {
         List<Board> boards = member.getBoardList();
         boards.add(board);
-        memberRepository.save(member);
+        member.setBoardList(boards);
     }
 
     public void updateCommentListByMember(Member member, Comment comment) {
         List<Comment> comments = member.getCommentList();
         comments.add(comment);
-        memberRepository.save(member);
+        member.setCommentList(comments);
     }
 }

--- a/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
@@ -10,6 +10,7 @@ import org.hmanwon.domain.member.dto.response.NicknameResponse;
 import org.hmanwon.global.common.dto.ResponseDTO;
 import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,25 +19,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
+@Validated
 public class MemberController {
 
     private final MemberService memberService;
 
     @GetMapping("/nickname")
-    public ResponseEntity<DataBody<NicknameResponse>> getNickname(@RequestParam @NotBlank String nickname) {
-        return ResponseDTO.ok(memberService.findNickname(nickname), "닉네임 존재여부를 조회했습니다.");
+    public ResponseEntity<DataBody<NicknameResponse>> getNickname(@RequestParam @NotBlank(message = "닉네임을 입력해주세요") String nickname) {
+        return ResponseDTO.ok(memberService.findNickname(nickname), "닉네임 존재 여부 조회 완료");
     }
 
     @GetMapping("/comments")
     public ResponseEntity<DataBody<List<MyCommentResponseDto>>> getCommentsByMember() {
         Long memberId = 1L;
-        return ResponseDTO.ok(memberService.findCommentsByMember(memberId), "내 댓글 목록을 조회했습니다.");
+        return ResponseDTO.ok(memberService.findCommentsByMember(memberId), "내 댓글 목록 조회 완료");
     }
 
     @GetMapping("/boards")
     public ResponseEntity<DataBody<List<MyBoardsResponseDto>>> getBoardsByMember() {
         Long memberId = 1L;
-        return ResponseDTO.ok(memberService.findBoardsByMember(memberId), "내 게시글 목록을 조회했습니다.");
+        return ResponseDTO.ok(memberService.findBoardsByMember(memberId), "내 게시글 목록 조회 완료");
     }
-
 }

--- a/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
@@ -25,7 +25,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/nickname")
-    public ResponseEntity<DataBody<NicknameResponse>> getNickname(@RequestParam @NotBlank(message = "닉네임을 입력해주세요") String nickname) {
+    public ResponseEntity<DataBody<NicknameResponse>> getNickname(@RequestParam @NotBlank(message = "닉네임을 입력하세요") String nickname) {
         return ResponseDTO.ok(memberService.findNickname(nickname), "닉네임 존재 여부 조회 완료");
     }
 


### PR DESCRIPTION
# 변경 사항
- 닉네임 조회 시 @Validated를 통해 닉네임 notblank 유효성 검증
- member, auth, comment controller의 응답 메세지 "~했습니다" >  "~ 완료" 로 변경

# 확인 방법 (스크린샷 포함)
![image](https://github.com/happymanwon/Backend/assets/76683396/e77887b7-735a-4890-b272-0d80ec08056b)

![image](https://github.com/happymanwon/Backend/assets/76683396/cddf203e-572b-4323-baed-92a2635b0d47)

