### PR TITLE
[fix] msg -> message로 수정, 가게 상세 정보 수정, 상세 조회 부분 리스트 없앰

### DIFF
--- a/src/main/java/org/hmanwon/domain/shop/application/ShopService.java
+++ b/src/main/java/org/hmanwon/domain/shop/application/ShopService.java
@@ -36,10 +36,10 @@ public class ShopService {
             .collect(Collectors.toList());
     }
 
-    public List<SeoulGoodShopDetailResponse> getShopDetail(Long shopId) {
-        return seoulGoodShopRepository.findById(shopId)
-            .stream().map(SeoulGoodShopDetailResponse::fromEntity)
-            .collect(Collectors.toList());
+    public SeoulGoodShopDetailResponse getShopDetail(Long shopId) {
+        SeoulGoodShop shop =  seoulGoodShopRepository.findById(shopId)
+                .orElseThrow(() -> new ShopException(NOT_FOUND_SHOP));
+        return SeoulGoodShopDetailResponse.fromEntity(shop);
     }
 
     public List<SeoulGoodShopResponse> searchShopByKeyword(String keyword) {

--- a/src/main/java/org/hmanwon/domain/shop/presentation/ShopController.java
+++ b/src/main/java/org/hmanwon/domain/shop/presentation/ShopController.java
@@ -44,7 +44,7 @@ public class ShopController {
 
 
     @GetMapping("/{shopId}")
-    public ResponseEntity<DataBody<List<SeoulGoodShopDetailResponse>>> getShopDetail(
+    public ResponseEntity<DataBody<SeoulGoodShopDetailResponse>> getShopDetail(
         @PathVariable final Long shopId
     ) {
         return ResponseDTO.ok(

--- a/src/main/java/org/hmanwon/global/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/org/hmanwon/global/common/dto/ErrorResponseDTO.java
@@ -11,7 +11,7 @@ public class ErrorResponseDTO {
 
     private final HttpStatus status;
     private final String code;
-    private final String msg;
+    private final String message;
 
     public static ErrorResponseDTO error(ExceptionCode exceptionCode) {
         return new ErrorResponseDTO(


### PR DESCRIPTION
# 변경 사항

## 에러를 다음과 같이 수정하였습니다. 
msg -> message 변수 명 수정 

<img width="851" alt="스크린샷 2023-12-11 오후 1 51 32" src="https://github.com/happymanwon/Backend/assets/59862752/5271fa5d-e506-40e6-92ca-4d3b6425d25a">

## 착한 가격 업소 짠 지도 상세 조회
리스트 -> 단순 객체로 바꿨습니다. 
```
{
    "data": {
        "id": 2,
        "way": "면목2동 다울아파트에서 동일로로 가는 골목에 위치",
        "imageUrl": "http://sftc.seoul.go.kr/mulga/inc/img_view.jsp?filename=20151126102520.jpg",
        "name": "상록수미용실",
        "category": 5,
        "address": "서울특별시 중랑구 동일로99길 22 (면목동)",
        "roadAddress": "서울 중랑구 동일로99길 22",
        "latitude": "37.587922318728",
        "longitude": "127.078621025398",
        "likeCount": 432,
        "info": "영업시간 : 09:30~21:00\r",
        "menuList": [
            {
                "menuName": "미용료(파마)",
                "menuPrice": 22000
            },
            {
                "menuName": "커트",
                "menuPrice": 6000
            }
        ]
    },
    "message": "착한 가격 업소 상세 조회 완료"
}

``` 
https://www.notion.so/44662e630661403e8af394ab84bb2963?p=acfff024e7ff47eda14341262c66f63c&pm=s
