### PR TITLE
[refactor] 검색어 예외 처리 추가 및 글로벌 핸들러 변경

### DIFF
--- a/src/main/java/org/hmanwon/domain/shop/presentation/ShopController.java
+++ b/src/main/java/org/hmanwon/domain/shop/presentation/ShopController.java
@@ -2,7 +2,9 @@ package org.hmanwon.domain.shop.presentation;
 
 import java.util.List;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.hmanwon.domain.shop.application.ShopService;
 import org.hmanwon.domain.shop.dto.SeoulGoodShopDetailResponse;
 import org.hmanwon.domain.shop.dto.SeoulGoodShopResponse;
@@ -13,6 +15,7 @@ import org.hmanwon.domain.shop.exception.ShopExceptionCode;
 import org.hmanwon.global.common.dto.ResponseDTO;
 import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/shops")
 @RequiredArgsConstructor
+@Validated
 public class ShopController {
 
     private final ShopService shopService;
@@ -55,7 +59,10 @@ public class ShopController {
 
     @GetMapping("/search")
     public ResponseEntity<DataBody<List<SeoulGoodShopResponse>>> searchShopByKeyword(
-        @RequestParam(name = "keyword") final String keyword
+        @Valid @RequestParam(name = "keyword")
+        @Length(min = 1, max = 15, message = "검색어는 1글자 ~ 15글자 사이어야 합니다")
+        @NotBlank(message = "검색어를 채워주세요")
+        final String keyword
     ) {
         return ResponseDTO.ok(
             shopService.searchShopByKeyword(keyword),

--- a/src/main/java/org/hmanwon/global/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/org/hmanwon/global/common/exception/DefaultExceptionHandler.java
@@ -5,8 +5,10 @@ import static org.hmanwon.global.common.exception.DefaultExceptionCode.INTERNAL_
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.hmanwon.global.common.dto.ErrorResponseDTO;
@@ -88,13 +90,15 @@ public class DefaultExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleConstraintViolationException(
         ConstraintViolationException e, HttpServletRequest request
     ) {
+
         log.error("ConstraintViolationException error url : {}, message : {}",
             request.getRequestURI(),
             e.getMessage()
         );
-        //searchTripListByKeyword.keyword: 검색어를 채워주세요 -> "검색어를 채워주세요" 반환.
-        String[] msgList = e.getMessage().split(":");
-        String msg = msgList[msgList.length - 1].substring(1);
+
+        String msg = e.getConstraintViolations().stream()
+                .map( cv -> cv == null ? "null" : cv.getMessage() )
+                .collect( Collectors.joining( ", " ) );
 
         return new ResponseEntity<>(
             new ErrorResponseDTO(


### PR DESCRIPTION
# 변경 사항

다음과 같이 글로벌 예외처리 코드가 변경되었습니다. 
@RequestParam으로 오는 @Valid 예외도 기존에는 1개만 메시지를 보여줬다면
이제는 전부 보여줍니다!
``` java
@ExceptionHandler(value = {
        ConstraintViolationException.class
    })
    public ResponseEntity<ErrorResponseDTO> handleConstraintViolationException(
        ConstraintViolationException e, HttpServletRequest request
    ) {

        String msg = e.getConstraintViolations().stream()
                .map( cv -> cv == null ? "null" : cv.getMessage() )
                .collect( Collectors.joining( ", " ) );

        return new ResponseEntity<>(
            new ErrorResponseDTO(
                BAD_REQUEST.getStatus(),
                BAD_REQUEST.getCode(),
                msg
            ),
            HttpStatus.BAD_REQUEST
        );
    }
``` 

검색어 예외 처리 추가 하였습니다. 
착한 가격 업소 검색 시 NotBlank 및 혹시 모를 글자 수 제한을 걸었습니다. 
```java
    @GetMapping("/search")
    public ResponseEntity<DataBody<List<SeoulGoodShopResponse>>> searchShopByKeyword(
        @Valid @RequestParam(name = "keyword")
        @Length(min = 1, max = 15, message = "검색어는 1글자 ~ 15글자 사이어야 합니다")
        @NotBlank(message = "검색어를 채워주세요")
        final String keyword
    ) {
        return ResponseDTO.ok(
            shopService.searchShopByKeyword(keyword),
            "착한 가격 업소 검색 완료"
        );
    }
``` 


# 확인 방법 (스크린샷 포함)

<img width="1079" alt="스크린샷 2023-12-11 오후 3 32 45" src="https://github.com/happymanwon/Backend/assets/59862752/84acba1d-32ce-48c1-8a7d-e0d1ed57f3fc">

<img width="1040" alt="스크린샷 2023-12-11 오후 3 37 59" src="https://github.com/happymanwon/Backend/assets/59862752/bf10ab11-9b83-4a16-9d54-ab072ad82fc7">

