### PR TITLE
Feature/auth api 인증 서비스 보완

### DIFF
--- a/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
+++ b/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
@@ -164,7 +164,7 @@ public class AuthService {
         return memberInfo;
     }
 
-    private Long findMemberIdFromTokenWithValidation(String headerToken) {
+    public Long findMemberIdFromTokenWithValidation(String headerToken) {
         //예외처리 필요
         String token = headerToken;
         Long memberId = -1L;

--- a/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
+++ b/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
     private final MemberService memberService;
     private final JwtProvider jwtProvider;
 
-    @Value("${kakao.rest_api_key}")
+    @Value("${kakao.restApiKey}")
     String clientId;
     String redirectURL = "http://localhost:8080/api/auth/login/kakao";
 

--- a/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
+++ b/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
@@ -164,7 +164,7 @@ public class AuthService {
         return memberInfo;
     }
 
-    public Long findMemberIdFromTokenWithValidation(String headerToken) {
+    public Long getMemberIdFromValidToken(String headerToken) {
         //예외처리 필요
         String token = headerToken;
         Long memberId = -1L;

--- a/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
+++ b/src/main/java/org/hmanwon/domain/auth/application/AuthService.java
@@ -36,7 +36,7 @@ public class AuthService {
 
     @Value("${kakao.restApiKey}")
     String clientId;
-    String redirectURL = "http://localhost:8080/api/auth/login/kakao";
+    String redirectURL = "http://118.67.134.91:8080/api/auth/login/kakao";
 
     public AuthLoginResponse kakaoLogin(String kakaoAuthorizationCode) {
         //인가코드 받아서 카카오 토큰 발급

--- a/src/main/java/org/hmanwon/domain/auth/application/JwtProvider.java
+++ b/src/main/java/org/hmanwon/domain/auth/application/JwtProvider.java
@@ -55,11 +55,11 @@ public class JwtProvider {
         return claims.getSubject();
     }
 
-    public String getMemberIdFromToken(String token) {
+    public Long getMemberIdFromToken(String token) {
         Claims claims = Jwts.parser()
             .setSigningKey(secretKey)
             .parseClaimsJws(token).getBody();
-        return (String) claims.get("memberId");
+        return (Long) claims.get("memberId");
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/org/hmanwon/domain/auth/exception/AuthException.java
+++ b/src/main/java/org/hmanwon/domain/auth/exception/AuthException.java
@@ -1,0 +1,11 @@
+package org.hmanwon.domain.auth.exception;
+
+import org.hmanwon.global.common.exception.DefaultException;
+import org.hmanwon.global.common.exception.ExceptionCode;
+
+public class AuthException extends DefaultException {
+
+    public AuthException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+}

--- a/src/main/java/org/hmanwon/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/org/hmanwon/domain/auth/exception/AuthExceptionCode.java
@@ -1,0 +1,25 @@
+package org.hmanwon.domain.auth.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hmanwon.global.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthExceptionCode implements ExceptionCode {
+
+    UNAUTHORIZED_TOKEN(UNAUTHORIZED, "Auth Error 01", "토큰이 유효하지 않습니다."),
+    KAKAO_NETWORK_ERROR(INTERNAL_SERVER_ERROR, "Auth Erorr 02", "카카오 서버와의 통신 문제가 발생하였습니다."),
+    INVALID_TOKEN(BAD_REQUEST, "Auth Erorr 03", "토큰이 빈문자열 혹은 NULL값입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+}

--- a/src/main/java/org/hmanwon/domain/member/application/MemberService.java
+++ b/src/main/java/org/hmanwon/domain/member/application/MemberService.java
@@ -45,6 +45,16 @@ public class MemberService {
             .build();
     }
 
+    public MemberResponse findMemberInfo(Long memberId) {
+        Member member = findMemberById(memberId);
+        return MemberResponse.builder()
+            .memberId(member.getId())
+            .email(member.getEmail())
+            .nickname(member.getNickname())
+            .point(member.getPoint())
+            .build();
+    }
+
     public List<MyCommentResponseDto> findCommentsByMember(Long memberId) {
 
         Member member = findMemberById(memberId);

--- a/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
@@ -3,8 +3,10 @@ package org.hmanwon.domain.member.presentation;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.hmanwon.domain.auth.application.AuthService;
 import org.hmanwon.domain.community.board.dto.response.BoardResponse;
 import org.hmanwon.domain.member.application.MemberService;
+import org.hmanwon.domain.member.dto.response.MemberResponse;
 import org.hmanwon.domain.member.dto.response.MyCommentResponseDto;
 import org.hmanwon.domain.member.dto.response.NicknameResponse;
 import org.hmanwon.global.common.dto.ResponseDTO;
@@ -12,6 +14,7 @@ import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,9 +26,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final AuthService authService;
 
     @GetMapping("/nickname")
-    public ResponseEntity<DataBody<NicknameResponse>> getNickname(@RequestParam @NotBlank(message = "닉네임을 입력하세요") String nickname) {
+    public ResponseEntity<DataBody<NicknameResponse>> getNickname(
+        @RequestParam @NotBlank(message = "닉네임을 입력하세요") String nickname) {
         return ResponseDTO.ok(memberService.findNickname(nickname), "닉네임 존재 여부 조회 완료");
     }
 
@@ -39,5 +44,13 @@ public class MemberController {
     public ResponseEntity<DataBody<List<BoardResponse>>> getBoardsByMember() {
         Long memberId = 1L;
         return ResponseDTO.ok(memberService.findBoardsByMember(memberId), "내 게시글 목록 조회 완료");
+    }
+
+    @GetMapping
+    public ResponseEntity<DataBody<MemberResponse>> getMemberInfo(
+        @RequestHeader(value = "Authorization") String token) {
+        return ResponseDTO.ok(
+            memberService.findMemberInfo(authService.findMemberIdFromTokenWithValidation(token)),
+            "회원 정보 조회 완료");
     }
 }

--- a/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/hmanwon/domain/member/presentation/MemberController.java
@@ -50,7 +50,7 @@ public class MemberController {
     public ResponseEntity<DataBody<MemberResponse>> getMemberInfo(
         @RequestHeader(value = "Authorization") String token) {
         return ResponseDTO.ok(
-            memberService.findMemberInfo(authService.findMemberIdFromTokenWithValidation(token)),
+            memberService.findMemberInfo(authService.getMemberIdFromValidToken(token)),
             "회원 정보 조회 완료");
     }
 }

--- a/src/main/java/org/hmanwon/domain/shop/init/util/KakaoApiUtil.java
+++ b/src/main/java/org/hmanwon/domain/shop/init/util/KakaoApiUtil.java
@@ -16,7 +16,7 @@ public class KakaoApiUtil {
 
     private final String REST_API_KEY;
 
-    public KakaoApiUtil(@Value("${kakao.rest_api_key}") String key) {
+    public KakaoApiUtil(@Value("${kakao.restApiKey}") String key) {
         REST_API_KEY = key;
     }
 

--- a/src/main/java/org/hmanwon/global/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/org/hmanwon/global/common/exception/DefaultExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -115,7 +116,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(value = {
         MethodArgumentNotValidException.class
     })
-    public ResponseEntity<ErrorResponseDTO> handleArgumentNotVaildException(
+    public ResponseEntity<ErrorResponseDTO> handleArgumentNotValidException(
         MethodArgumentNotValidException e, HttpServletRequest request
     ) {
         log.error("MethodArgumentNotValid error url : {}, message : {}",
@@ -137,6 +138,21 @@ public class DefaultExceptionHandler {
         );
     }
 
+    @ExceptionHandler(value = {
+        MissingRequestHeaderException.class
+    })
+    public ResponseEntity<ErrorResponseDTO> handleMissingRequestHeaderException(
+        MissingRequestHeaderException e
+    ) {
+        return new ResponseEntity<>(
+            new ErrorResponseDTO(
+                BAD_REQUEST.getStatus(),
+                BAD_REQUEST.getCode(),
+                e.getMessage()
+            ),
+            HttpStatus.BAD_REQUEST
+        );
+    }
     /**
      * 기타 예외 처리
      *

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ server:
   port: 8080
 
 kakao:
-  rest_api_key : KakaoAK 2d10cd365cbf8f56eda4e243e68f505e
+  restApiKey : dceb1b292320a7621e7a4cbbbaf81531
 jwt:
   secretKey: hmanwonsecretkey
   accessTokenValidTime: 86400000


### PR DESCRIPTION
# 변경 사항
- 등록한 애플리케이션의 앱 키 적용
- 헤더토큰에서 실제토큰 추출 + 토큰 유효성 검증 + memberId조회 하는 메서드 구현
- 인증 서비스 예외처리
- 회원 정보 조회 API (컨트롤러에서 토큰 받아와서 memberId 추출하는 방식 적용: authService의 메서드 이용)
- 헤더에 토큰 미전달시 예외 발생 -> 글로벌 핸들러 예외처리

# 확인 방법 (스크린샷 포함)
