### PR TITLE
fix: 로그인 api GET으로 변경

### DIFF
--- a/src/main/java/org/hmanwon/domain/auth/presentation/AuthController.java
+++ b/src/main/java/org/hmanwon/domain/auth/presentation/AuthController.java
@@ -6,6 +6,7 @@ import org.hmanwon.domain.auth.dto.AuthLoginResponse;
 import org.hmanwon.global.common.dto.ResponseDTO;
 import org.hmanwon.global.common.dto.ResponseDTO.DataBody;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,7 +19,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/login/kakao")
+    @GetMapping("/login/kakao")
     public ResponseEntity<DataBody<AuthLoginResponse>> KakaoLogin(@RequestParam String code) {
         return ResponseDTO.ok(authService.kakaoLogin(code), "카카오 로그인 완료");
     }


### PR DESCRIPTION
# 반영 브랜치

# 변경 사항
카카오 로그인 API HTTP 메서드 POST->GET 변경
# 확인 방법 (스크린샷 포함)
